### PR TITLE
Updated Tokenizer to use ReadOnlySpans

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: Build
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: continuous-delivery
+name: "CD"
 run-name: Publish pipeline after ${{github.event_name}} by @${{ github.actor }}
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: continuous-integration
+name: "CI"
 run-name: Build pipeline after ${{github.event_name}} by @${{ github.actor }}
 
 on:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: publish
+name: Publish
 on:
   workflow_call:
     inputs:

--- a/src/SqlParser/Dialects/Dialect.cs
+++ b/src/SqlParser/Dialects/Dialect.cs
@@ -36,7 +36,7 @@ public abstract class Dialect
     /// Determine if quoted characters are proper for identifier
     /// </summary>
     /// <returns>True if proper; otherwise false.</returns>
-    public virtual bool IsProperIdentifierInsideQuotes(IState state)
+    public virtual bool IsProperIdentifierInsideQuotes(State state)
     {
         return true;
     }

--- a/src/SqlParser/Dialects/RedshiftDialect.cs
+++ b/src/SqlParser/Dialects/RedshiftDialect.cs
@@ -30,7 +30,7 @@ public class RedshiftDialect : Dialect
     /// It's needed to distinguish treating square brackets as quotes from
     /// treating them as json path. If there is identifier then we assume
     /// there is no json path.
-    public override bool IsProperIdentifierInsideQuotes(IState state)
+    public override bool IsProperIdentifierInsideQuotes(State state)
     {
         state.Next();
         var notWhiteChar = state.SkipWhile(c => string.IsNullOrWhiteSpace(c.ToString()));

--- a/src/SqlParser/Parser.cs
+++ b/src/SqlParser/Parser.cs
@@ -48,7 +48,7 @@ public class Parser
     /// <returns></returns>
     /// <exception cref="TokenizeException">Thrown when an unexpected token in encountered while parsing the input string</exception>
     /// <exception cref="ParserException">Thrown when the sequence of tokens does not match the dialect's expected grammar</exception>
-    public Sequence<Statement> ParseSql(string sql, ParserOptions? options = null)
+    public Sequence<Statement> ParseSql(ReadOnlySpan<char> sql, ParserOptions? options = null)
     {
         return ParseSql(sql, new GenericDialect(), options);
     }
@@ -59,7 +59,7 @@ public class Parser
     /// <param name="dialect">SQL dialect instance</param>
     /// <param name="options">Parsing options</param>
     /// <returns></returns>
-    public Sequence<Statement> ParseSql(string sql, Dialect dialect, ParserOptions? options = null)
+    public Sequence<Statement> ParseSql(ReadOnlySpan<char> sql, Dialect dialect, ParserOptions? options = null)
     {
         _options = options ?? new ParserOptions();
         _depthGuard = new DepthGuard(_options.RecursionLimit);
@@ -71,7 +71,7 @@ public class Parser
         return ParseStatements();
     }
 
-    internal Parser TryWithSql(string sql, Dialect dialect, ParserOptions? options = null)
+    internal Parser TryWithSql(ReadOnlySpan<char> sql, Dialect dialect, ParserOptions? options = null)
     {
         _options = options ?? new ParserOptions();
         _depthGuard = new DepthGuard(50);

--- a/src/SqlParser/State.cs
+++ b/src/SqlParser/State.cs
@@ -1,33 +1,26 @@
-﻿
-namespace SqlParser;
+﻿namespace SqlParser;
 
-public interface IState
+public ref struct State
 {
-    void Next();
-    char? SkipWhile(Func<char, bool> skipPredicate);
-}
-
-public class State : IState
-{
-    private readonly char[] _characters;
+    private readonly ReadOnlySpan<char> _characters;
     private readonly Location _location;
-    private long _index;
+    private int _index;
     private bool _finished;
 
-    internal State(string sql)
+    internal State(ReadOnlySpan<char> sql)
     {
-        _characters = sql.ToCharArray();
+        _characters = sql;
         _location = new Location();
     }
 
-    private State(long index, Location location, char[] characters)
+    private State(int index, Location location, ReadOnlySpan<char> characters)
     {
-        _index= index;
+        _index = index;
         _location = location;
         _characters = characters;
     }
 
-    internal char Peek()
+    public char Peek()
     {
         if (_finished)
         {
@@ -85,8 +78,6 @@ public class State : IState
 
     internal State Clone()
     {
-        var cloneCharacters = new char[_characters.Length];
-        _characters.CopyTo(cloneCharacters, 0);
-        return new State(_index, CloneLocation(), cloneCharacters);
+        return new State(_index, CloneLocation(), _characters);
     }
 }


### PR DESCRIPTION
Updated Tokenizer to use `ReadOnlySpan<char>` as a` ref struct `object instead of a class with character arrays.