### PR TITLE
avoid some alloc in EscapeEscapedString

### DIFF
--- a/src/SqlParser/Extensions.cs
+++ b/src/SqlParser/Extensions.cs
@@ -231,17 +231,29 @@ internal static class Extensions
 
         var builder = StringBuilderPool.Get();
 
-        foreach (var escaped in value.Select(character => character switch
-                 {
-                     Symbols.SingleQuote => @"\'",
-                     Symbols.Backslash => @"\\",
-                     Symbols.NewLine => @"\n",
-                     Symbols.Tab => @"\t",
-                     Symbols.CarriageReturn => @"\r",
-                     _ => character.ToString()
-                 }))
+        foreach (var ch in value)
         {
-            builder.Append(escaped);
+            switch (ch)
+            {
+                case Symbols.SingleQuote:
+                    builder.Append(@"\'");
+                    break;
+                case Symbols.Backslash:
+                    builder.Append(@"\\");
+                    break;
+                case Symbols.NewLine:
+                    builder.Append(@"\n");
+                    break;
+                case Symbols.Tab:
+                    builder.Append(@"\t");
+                    break;
+                case Symbols.CarriageReturn:
+                    builder.Append(@"\r");
+                    break;
+                default:
+                    builder.Append(ch);
+                    break;
+            }
         }
 
         return StringBuilderPool.Return(builder);


### PR DESCRIPTION
slight more verbose. but

 * avoids some linq alloc
 * avoids a tostring alloc on the ch for non matches
 * means we can leverage the faster stringbuilder path of passing a char, instead of a string with a length of 1