### PR TITLE
Bugfix: where dialect permits identifiers to be single-quoted, ColumDefinitions are properly recognised

### DIFF
--- a/src/SqlParser/Parser.cs
+++ b/src/SqlParser/Parser.cs
@@ -4602,11 +4602,11 @@ public partial class Parser
             {
                 constraints.Add(constraint);
             }
-            else if (PeekToken() is Word)
+            else if ((PeekToken() is Word) || (PeekToken() is SingleQuotedString))
             {
                 columns.Add(ParseColumnDef());
             }
-            else
+            else 
             {
                 ThrowExpected("column name or constraint definition", PeekToken());
             }


### PR DESCRIPTION
In SQLite (and others that permit single-quoted identifiers):

    create table 'test'('id' integer)

failed at `'id'`.  Although single-quoted tokens are treated tolerantly in `ParseIdentifierWithClause()`, only properly-formed `Word`s were recognised in `ParseColumns()`.   (As far as I can tell, all other uses parse correctly.)