### PR TITLE
Bugfix: SQLite doesn't need commas between adjacent table constraints

### DIFF
--- a/src/SqlParser/Parser.cs
+++ b/src/SqlParser/Parser.cs
@@ -5014,9 +5014,9 @@ public partial class Parser
         }
     }
 
-    public TableConstraint? ParseOptionalTableConstraint(bool noThrowOnDefault = false)
+    public TableConstraint? ParseOptionalTableConstraint(bool isSubsequentConstraint = false)
     {
-        var name = ParseInit(ParseKeyword(Keyword.CONSTRAINT), ParseIdentifier);
+        var name = isSubsequentConstraint ? null : ParseInit(ParseKeyword(Keyword.CONSTRAINT), ParseIdentifier);
 
         var token = NextToken();
 
@@ -5144,7 +5144,7 @@ public partial class Parser
 
         TableConstraint? ParseDefault()
         {
-            if ((name != null) && !noThrowOnDefault)
+            if ((name != null) && !isSubsequentConstraint)
             {
                 ThrowExpected("PRIMARY, UNIQUE, FOREIGN, or CHECK", token);
             }


### PR DESCRIPTION
Even though the spec doesn't allow it, SQLite actually accepts multiple table constraints without intervening commas, just like column constraints.  Like this:

    CREATE TABLE test (id INTEGER, name TEXT, PRIMARY KEY (id) UNIQUE(name))

There are enough examples of this in the wild that I suspect it should be supported.

The approach I've taken is to treat every constraint independently.  I've seen examples like this:

    CREATE TABLE test (id INTEGER, name TEXT, CONSTRAINT cname PRIMARY KEY (id) UNIQUE(name))

which I think should be interpeted thus:

    CREATE TABLE test (id INTEGER, name TEXT, CONSTRAINT cname PRIMARY KEY (id), UNIQUE(name))

It's not really ideal, but is peferable to the alternative (which is that every constraint in every dialect would have to be multiple, including `ALTER TABLE ADD CONSTRAINT ...`, which I rejected because:

- It would do too much violence to the rest of the code,;
- It doesn't have any benefit in SQLite which doesn't let you alter constraints anyway.

I don't think this should mean anything:

    CREATE TABLE test (id INTEGER, name TEXT, CONSTRAINT pname PRIMARY KEY (id)  CONSTRAINT uname UNIQUE(name))

so I've suppressed looking for another `CONSTRAINT` keyword on subsequent clauses.   
