### PR TITLE
Correct handling for blank input

### DIFF
--- a/src/SqlParser/State.cs
+++ b/src/SqlParser/State.cs
@@ -29,7 +29,7 @@ public ref struct State
 
         if (_index >= _characters.Length)
         {
-            throw new ParserException($"Parser unable to read character at index {_index}");
+            return Symbols.EndOfFile;
         }
         return _finished ? Symbols.EndOfFile : _characters[_index];
     }


### PR DESCRIPTION
When the parser is presetned with either empty input or one space, it throws an exception.  When it's presented with mutliple spaces, it returns an empty statement structure.

I think the correct response is to return empty in either case.  This fix delivers that.