### PR TITLE
Read and store complex primary key definitions

### DIFF
--- a/src/SqlParser/Ast/ColumnOption.cs
+++ b/src/SqlParser/Ast/ColumnOption.cs
@@ -57,11 +57,23 @@ public abstract record ColumnOption : IWriteSql, IElement
     public record Unique(bool IsPrimary) : ColumnOption
     {
         public ConstraintCharacteristics? Characteristics { get; init; }
-       
+        public Keyword? Order { get; internal set; }
+        public Keyword? Conflict { get; internal set; }
+        public bool Autoincrement { get; internal set; }
+
         public override void ToSql(SqlTextWriter writer)
         {
             writer.Write(IsPrimary ? "PRIMARY KEY" : "UNIQUE");
 
+            if (Order != null) {
+                writer.WriteSql($" {Order}");
+            }
+            if (Conflict != null) {
+                writer.WriteSql($" ON CONFLICT {Conflict}");
+            }
+            if (Autoincrement) {
+                writer.WriteSql($" AUTOINCREMENT");
+            }
             if (Characteristics != null)
             {
                 writer.WriteSql($" {Characteristics}");

--- a/src/SqlParser/Parser.cs
+++ b/src/SqlParser/Parser.cs
@@ -15,6 +15,7 @@ using Select = SqlParser.Ast.Select;
 using Declare = SqlParser.Ast.Declare;
 using HiveRowDelimiter = SqlParser.Ast.HiveRowDelimiter;
 using Subscript = SqlParser.Ast.Subscript;
+using System.Data;
 
 namespace SqlParser;
 
@@ -4696,6 +4697,11 @@ public partial class Parser
         }
     }
 
+    public Keyword? ParseColumnConflictClause () {
+        if (!ParseKeywordSequence(Keyword.ON, Keyword.CONFLICT)) return null;
+        return ParseOneOfKeywords(Keyword.ROLLBACK, Keyword.ABORT, Keyword.FAIL, Keyword.IGNORE, Keyword.REPLACE);
+    }
+
     public ColumnOption? ParseOptionalColumnOption()
     {
         if (ParseKeywordSequence(Keyword.CHARACTER, Keyword.SET))
@@ -4731,19 +4737,26 @@ public partial class Parser
 
         if (ParseKeywordSequence(Keyword.PRIMARY, Keyword.KEY))
         {
+            var order = _dialect is SQLiteDialect ? ParseOneOfKeywords([Keyword.ASC, Keyword.DESC]) : Keyword.undefined;
+            var conflict = _dialect is SQLiteDialect ? ParseColumnConflictClause() : Keyword.undefined;
+            var autoincrement = _dialect is SQLiteDialect && ParseKeyword(Keyword.AUTOINCREMENT);
             var characteristics = ParseConstraintCharacteristics();
-            return new ColumnOption.Unique(true)
-            {
-                Characteristics = characteristics
+            return new ColumnOption.Unique(true) {
+                Characteristics = characteristics,
+                Order = order != Keyword.undefined ? order : null,
+                Conflict = conflict != Keyword.undefined ? conflict : null,
+                Autoincrement = autoincrement
             };
         }
 
         if (ParseKeyword(Keyword.UNIQUE))
         {
+            var conflict = _dialect is SQLiteDialect ? ParseColumnConflictClause() : Keyword.undefined;
             var characteristics = ParseConstraintCharacteristics();
             return new ColumnOption.Unique(false)
             {
-                Characteristics = characteristics
+                Characteristics = characteristics,
+                Conflict = conflict
             };
         }
 


### PR DESCRIPTION
SQLite has a more complex `PRIMARY KEY` than most dialects.  The following is legal:

    CREATE TABLE test (id INTEGER PRIMARY KEY DESC ON CONFLICT ROLLBACK AUTOINCREMENT);

It's not really easy to patch around this using more conventional structures so I reckon these should be parsed accurately.  This PR provides a complete parsing solution