### PR TITLE
Add support for index constraint added when altering a table (Postgres)

### DIFF
--- a/src/SqlParser/Ast/TableConstraint.cs
+++ b/src/SqlParser/Ast/TableConstraint.cs
@@ -123,6 +123,32 @@ public abstract record TableConstraint : IWriteSql, IElement
     }
 
     /// <summary>
+    /// Index constraint added as part of an alter table statement.
+    /// As far as I know, Postgres specific.
+    ///
+    /// `[ CONSTRAINT constraint_name ] { UNIQUE | PRIMARY KEY } USING INDEX index_name [ DEFERRABLE | NOT DEFERRABLE ] [ INITIALLY DEFERRED | INITIALLY IMMEDIATE ]`
+    ///
+    /// <see href="https://www.postgresql.org/docs/current/sql-altertable.html"/>
+    /// </summary>
+    public record PostgresAlterTableIndex(Ident Name, Ident IndexName) : TableConstraint
+    {
+        public ConstraintCharacteristics? Characteristics { get; init; }
+        public bool IsPrimaryKey { get; init; }
+
+        public override void ToSql(SqlTextWriter writer)
+        {
+            writer.Write("CONSTRAINT");
+            writer.WriteSql($" {Name}");
+            writer.Write(IsPrimaryKey ? " PRIMARY KEY" : " UNIQUE");
+            writer.Write(" USING INDEX");
+            writer.WriteSql($" {IndexName}");
+            if (Characteristics != null)
+            {
+                writer.WriteSql($" {Characteristics}");
+            }
+        }
+    }
+    /// <summary>
     /// MySQLs [fulltext][1] definition. Since the [`SPATIAL`][2] definition is exactly the same,
     /// and MySQL displays both the same way, it is part of this definition as well.
     ///

--- a/src/SqlParser/Parser.cs
+++ b/src/SqlParser/Parser.cs
@@ -5020,14 +5020,14 @@ public partial class Parser
     bool ParseAnyOptionalTableConstraints(Action<TableConstraint> action) {
         bool any = false;
         while (true) {
-            var constraint = ParseOptionalTableConstraint(any);
+            var constraint = ParseOptionalTableConstraint(any, false);
             if (constraint == null) return any;
             action(constraint);
             any = true;
         }
     }
 
-    public TableConstraint? ParseOptionalTableConstraint(bool isSubsequentConstraint = false)
+    public TableConstraint? ParseOptionalTableConstraint(bool isSubsequentConstraint, bool isAlterTable)
     {
         var name = isSubsequentConstraint ? null : ParseInit(ParseKeyword(Keyword.CONSTRAINT), ParseIdentifier);
 
@@ -5050,18 +5050,31 @@ public partial class Parser
             var isPrimary = word.Keyword == Keyword.PRIMARY;
             ParseKeyword(Keyword.KEY);
 
-            // Optional constraint name
-            var identName = MaybeParse(ParseIdentifier) ?? name;
-
-            var columns = ParseParenthesizedColumnList(IsOptional.Mandatory, false);
-            var characteristics = ParseConstraintCharacteristics();
-
-            return new TableConstraint.Unique(columns)
+            if (_dialect is PostgreSqlDialect && isAlterTable && PeekToken() is Word { Keyword: Keyword.USING })
             {
-                Name = identName,
-                IsPrimaryKey = isPrimary,
-                Characteristics = characteristics
-            };
+                ParseKeywordSequence(Keyword.USING, Keyword.INDEX);
+                var indexName = ParseIdentifier();
+                var characteristics = ParseConstraintCharacteristics();
+
+                return new TableConstraint.PostgresAlterTableIndex(name, indexName)
+                {
+                    Characteristics = characteristics,
+                    IsPrimaryKey = isPrimary
+                };
+            }
+            else
+            {
+                // Optional constraint name
+                var identName = MaybeParse(ParseIdentifier) ?? name;
+                var columns = ParseParenthesizedColumnList(IsOptional.Mandatory, false);
+                var characteristics = ParseConstraintCharacteristics();
+                return new TableConstraint.Unique(columns)
+                {
+                    Name = identName,
+                    IsPrimaryKey = isPrimary,
+                    Characteristics = characteristics
+                };
+            }
         }
 
         TableConstraint ParseForeign()
@@ -5327,7 +5340,7 @@ public partial class Parser
 
         if (ParseKeyword(Keyword.ADD))
         {
-            var constraint = ParseOptionalTableConstraint();
+            var constraint = ParseOptionalTableConstraint(false, true);
             if (constraint != null)
             {
                 operation = new AddConstraint(constraint);


### PR DESCRIPTION
Hey! I was playing a bit around with using this library as part of some automated testing of our PostgreSQL queries.

I hit a case that wasn't covered, as it is probably quite an edge case. Specifically, the `table_constraint_using_index` case from: https://www.postgresql.org/docs/current/sql-altertable.html for example:

```ALTER TABLE table_name ADD CONSTRAINT constraint_name UNIQUE USING INDEX index_name```

I must admit that I haven't checked if this is present on ANSI, so I've considered it Postgres specific.

It's also specific to `ALTER TABLE` statements, which also makes the code a bit iffy.

I am not sure when I can come back to this, so feel free to make any changes to the branch you see fit i I'm not back in a timely manner. Given that this might be a bit of an edge case for the library, I also completely respect if you don't think this change is fit for purpose.