### PR TITLE
Allow for setting Expression.Args and TableFactor.Alias

### DIFF
--- a/src/SqlParser/Ast/Expression.cs
+++ b/src/SqlParser/Ast/Expression.cs
@@ -480,7 +480,7 @@ public abstract record Expression : IWriteSql, IElement
         /// <summary>
         /// Sequence function call
         /// </summary>
-        public FunctionArguments Args { get; internal set; }
+        public FunctionArguments Args { get; init; }
 
         public FunctionArguments Parameters { get; init; }
 

--- a/src/SqlParser/Ast/TableFactor.cs
+++ b/src/SqlParser/Ast/TableFactor.cs
@@ -8,7 +8,7 @@ public abstract record TableFactor : IWriteSql, IElement
     /// <summary>
     /// Common table alias across all implementations
     /// </summary>
-    [Visit(1)] public TableAlias? Alias { get; internal set; }
+    [Visit(1)] public TableAlias? Alias { get; set; }
     /// <summary>
     /// Derived table factor
     /// </summary>


### PR DESCRIPTION
The background here is that I'm trying to write some tests for a SQL builder library that targets multiple dialects and I'm trying to use `SqlParser` in the tests to describe and assert what the expected AST for the generated SQL is. Along the way, I've run into a couple of `internal set` properties that have required some hacky workarounds and I wondered if you'd be open to removing the `internal` modifier from some of these setters.

An example of such a workaround is:

```csharp
public TableFactor.Table MakeTableWithAlias(string tableName, string alias, Dialect dialect)
{
    var fabricatedQuery = $"select * from {tableName} as {alias}";
    var parsedQuery = sqlQueryParser.Parse(sql, dialect: dialect).First().AsSelect() ??
        throw new InvalidOperationException(
            $"Failed to parse SQL as select: {fabricatedQuery}");
    var body = Assert.IsType<SetExpression.SelectExpression>(parsedQuery.Query.Body);
    Assert.NotNull(body.Select.From);
    return body.Select.From.First().Relation as TableFactor.Table ??
        throw new InvalidOperationException(
            $"Failed to parse table with alias: {tableName} as {alias}");
}
```

This works for the simple case where I just want an `alias`, but would require other workarounds for other `TableFactor`-derived records.

There are still 8 other `internal set` properties, but I don't know enough about them to make any proposals at this time.

```
src/SqlParser/Ast/ColumnOption.cs:100:        public Keyword? Order { get; internal set; }
src/SqlParser/Ast/ColumnOption.cs:101:        public Keyword? Conflict { get; internal set; }
src/SqlParser/Ast/ColumnOption.cs:102:        public bool Autoincrement { get; internal set; }
src/SqlParser/Ast/CommonTableExpression.cs:14:    public Ident? From { get; internal set; } = From;
src/SqlParser/Ast/HiveFormat.cs:8:    public HiveRowFormat? RowFormat { get; internal set; }
src/SqlParser/Ast/HiveFormat.cs:9:    public Sequence<SqlOption>? SerdeProperties { get; internal set; }
src/SqlParser/Ast/HiveFormat.cs:10:    public HiveIOFormat? Storage { get; internal set; }
src/SqlParser/Ast/HiveFormat.cs:11:    public string? Location { get; internal set; }
```

Comments are welcome. Thanks in advance!