### PR TITLE
Add support for MS SQL-style IF statements in parser

### DIFF
--- a/src/SqlParser.Tests/Dialects/MsSqlDialectTests.cs
+++ b/src/SqlParser.Tests/Dialects/MsSqlDialectTests.cs
@@ -375,7 +375,7 @@ public class MsSqlDialectTests : ParserTestBase
     {
         var withColumnOptions = new List<(string, Sequence<ColumnOptionDef>)>
         {
-            ("CREATE TABLE mytable (columnA INT IDENTITY NOT NULL)", 
+            ("CREATE TABLE mytable (columnA INT IDENTITY NOT NULL)",
                 [
                     new ColumnOptionDef(new ColumnOption.Identity(new IdentityPropertyKind.Identity(new IdentityProperty(null, null)))),
                     new ColumnOptionDef(new ColumnOption.NotNull())
@@ -510,5 +510,17 @@ public class MsSqlDialectTests : ParserTestBase
         OneStatementParsesTo(
             "SELECT DISTINCT SUBSTRING(description, 0, 1) FROM test",
             "SELECT DISTINCT SUBSTRING(description, 0, 1) FROM test");
+    }
+
+    [Fact]
+    public void Parse_MsSql_If_ObjectId_Drop_Table()
+    {
+        const string sql = """
+                           IF OBJECT_ID(N'dbo.Users', N'U') IS NOT NULL
+                               DROP TABLE dbo.Users;
+                           """;
+        const string canonical = "IF OBJECT_ID(N'dbo.Users', N'U') IS NOT NULL DROP TABLE dbo.Users";
+
+        OneStatementParsesTo(sql, canonical);
     }
 }

--- a/src/SqlParser/Dialects/MsSqlDialect.cs
+++ b/src/SqlParser/Dialects/MsSqlDialect.cs
@@ -1,4 +1,7 @@
-﻿namespace SqlParser.Dialects;
+﻿using SqlParser.Ast;
+using SqlParser.Tokens;
+
+namespace SqlParser.Dialects;
 
 /// <summary>
 /// MS SQL dialect
@@ -7,6 +10,11 @@
 /// </summary>
 public class MsSqlDialect : Dialect
 {
+    public override Statement? ParseStatement(Parser parser)
+    {
+        return parser.ParseKeyword(Keyword.IF) ? ParseIfStatement(parser) : null;
+    }
+
     public override bool IsDelimitedIdentifierStart(char character)
     {
         return character is Symbols.DoubleQuote or Symbols.SquareBracketOpen;
@@ -17,18 +25,18 @@ public class MsSqlDialect : Dialect
         // See https://docs.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers?view=sql-server-2017#rules-for-regular-identifiers
         // We don't support non-latin "letters" currently.
 
-        return character.IsLetter() || 
-               character is Symbols.Underscore 
-                   or Symbols.Num 
+        return character.IsLetter() ||
+               character is Symbols.Underscore
+                   or Symbols.Num
                    or Symbols.At;
     }
 
     public override bool IsIdentifierPart(char character)
     {
         return character.IsAlphaNumeric() ||
-               character is Symbols.At 
+               character is Symbols.At
                    or Symbols.Dollar
-                   or Symbols.Num 
+                   or Symbols.Num
                    or Symbols.Underscore;
     }
 
@@ -37,4 +45,65 @@ public class MsSqlDialect : Dialect
     public override bool SupportsConnectBy => true;
     public override bool SupportsEqualAliasAssignment => true;
     public override bool SupportsTryConvert => true;
+
+    private static Statement ParseIfStatement(Parser parser)
+    {
+        var condition = parser.ParseExpr();
+
+        if (parser.ParseKeyword(Keyword.THEN))
+        {
+            var thenBody = parser.ParseStatementBlock();
+            var elseIfs = new Sequence<IfStatementElseIf>();
+
+            while (parser.ParseKeyword(Keyword.ELSEIF))
+            {
+                var elseIfCondition = parser.ParseExpr();
+                parser.ExpectKeyword(Keyword.THEN);
+                var elseIfBody = parser.ParseStatementBlock();
+                elseIfs.Add(new IfStatementElseIf(elseIfCondition, elseIfBody));
+            }
+
+            Sequence<Statement>? elseBlock = null;
+            if (parser.ParseKeyword(Keyword.ELSE))
+            {
+                elseBlock = parser.ParseStatementBlock();
+            }
+
+            parser.ExpectKeywords(Keyword.END, Keyword.IF);
+
+            return new Statement.If(new IfStatement(condition, thenBody)
+            {
+                ElseIfs = elseIfs.Any() ? elseIfs : null,
+                ElseBlock = elseBlock
+            });
+        }
+
+        var thenBlock = ParseIfBranchBody(parser);
+        parser.ConsumeToken<SemiColon>();
+
+        Sequence<Statement>? elseBlockStatement = null;
+        if (parser.ParseKeyword(Keyword.ELSE))
+        {
+            elseBlockStatement = ParseIfBranchBody(parser);
+            parser.ConsumeToken<SemiColon>();
+        }
+
+        return new Statement.If(new IfStatement(condition, thenBlock)
+        {
+            ElseBlock = elseBlockStatement,
+            Syntax = IfStatementSyntax.MsSql
+        });
+    }
+
+    private static Sequence<Statement> ParseIfBranchBody(Parser parser)
+    {
+        if (!parser.ParseKeyword(Keyword.BEGIN))
+        {
+            return [parser.ParseStatement()];
+        }
+
+        var statements = parser.ParseStatementBlock();
+        parser.ExpectKeyword(Keyword.END);
+        return statements;
+    }
 }


### PR DESCRIPTION
Extended the SQL parser and AST to handle MS SQL IF statements, including correct parsing and serialization of IF, ELSE IF, and ELSE branches with BEGIN/END blocks. Introduced IfStatementSyntax to distinguish between standard and MS SQL syntaxes. Added a unit test to verify parsing of typical MS SQL IF ... DROP TABLE ... statements.