### PR TITLE
Fix CI not running on pull requests targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,27 @@ on:
 
   pull_request:
     branches:
-      - feature/**
-      - bugfix/**
+      - main
 
 jobs:
+  validate-pr-branch-name:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce PR branch naming convention
+        run: |
+          branch="${{ github.head_ref }}"
+          if [[ ! "$branch" =~ ^(feature|bugfix)/ ]]; then
+            echo "::error::PR branch must start with 'feature/' or 'bugfix/'. Got: $branch"
+            exit 1
+          fi
+
   continuous-integration:
+    needs: validate-pr-branch-name
+    if: |
+      always() &&
+      (needs.validate-pr-branch-name.result == 'success' ||
+       needs.validate-pr-branch-name.result == 'skipped')
     uses: ./.github/workflows/build.yml
     with:
       pack: false


### PR DESCRIPTION
The `pull_request` trigger in `.github/workflows/ci.yml` filters on `branches: [feature/**, bugfix/**]`. That filter matches the **base** branch of the PR, not the source — so since contributor PRs target `main`, the workflow never fires. The test suite hasn't run on a PR in this repo.

Quick audit: PRs #62, #39, #38 have zero checks; #79 and #61 only have CodeQL (that's a separate workflow). No `CI` check anywhere.

Hit this after opening #84 and waiting for CI that never showed up.

## The fix

```diff
   pull_request:
     branches:
-      - feature/**
-      - bugfix/**
+      - main
```

That alone gets CI running on PRs, but it also drops the `feature/` / `bugfix/` naming intent. Which seems deliberate, so I'd rather preserve it properly.

## Preserving the naming intent

`pull_request.branches` can't express "source branch must start with X" — the filter only sees the base branch. Source-branch checks go in a job that reads `github.head_ref`:

```yaml
  validate-pr-branch-name:
    if: github.event_name == 'pull_request'
    runs-on: ubuntu-latest
    steps:
      - name: Enforce PR branch naming convention
        run: |
          branch="${{ github.head_ref }}"
          if [[ ! "$branch" =~ ^(feature|bugfix)/ ]]; then
            echo "::error::PR branch must start with 'feature/' or 'bugfix/'. Got: $branch"
            exit 1
          fi

  continuous-integration:
    needs: validate-pr-branch-name
    if: |
      always() &&
      (needs.validate-pr-branch-name.result == 'success' ||
       needs.validate-pr-branch-name.result == 'skipped')
    uses: ./.github/workflows/build.yml
    with:
      pack: false
    secrets: inherit
```

The validate job only runs on `pull_request` events, so direct pushes to `main` / `feature/**` / `bugfix/**` are untouched. The `always() && (success || skipped)` guard on `continuous-integration` is the important bit — it lets CI run both when validation passes (PR case) and when validation was skipped (push / dispatch case). Without it, GitHub's default "cascade skips downstream" would kill CI on pushes, which we don't want.

A PR from a non-conforming branch lands a red ❌ on `validate-pr-branch-name` with an actionable error; CI stays skipped until the contributor renames.

`push:` and `workflow_dispatch:` left alone.

## Making it binding

Right now the check is advisory — someone could still merge a PR with a red X. To block merges, add a branch protection rule on `main` requiring `validate-pr-branch-name`. Settings change, not a workflow change, so outside this PR.